### PR TITLE
Fix button types to prevent unwanted form submit

### DIFF
--- a/src/components/NewExpense/ExpenseForm.js
+++ b/src/components/NewExpense/ExpenseForm.js
@@ -59,7 +59,7 @@ const ExpenseForm = (props) => {
   return (
     <form onSubmit={submitHandler}>
       {toggle ? (
-        <button onClick={() => setToggle(false)}>Add new expense</button>
+        <button type="button" onClick={() => setToggle(false)}>Add new expense</button>
       ) : (
         <div>
           <div className="new-expense__controls">
@@ -96,7 +96,7 @@ const ExpenseForm = (props) => {
             </div>
           </div>
           <div className="new-expense__actions">
-            <button onClick={() => setToggle(true)}>Cancel</button>
+            <button type="button" onClick={() => setToggle(true)}>Cancel</button>
             <button type="submit">Add Expense</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- prevent form submission from `Add new expense` and `Cancel`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f14bda08326b3dd8179db51f03b