### PR TITLE
Fix comment clarity in ExpensesChart

### DIFF
--- a/src/components/Expenses/ExpensesChart.js
+++ b/src/components/Expenses/ExpensesChart.js
@@ -19,7 +19,7 @@ const ExpensesChart = (props) => {
   ];
 
   for (const expense of props.expenses) {
-    const expenseMonth = expense.date.getMonth(); // starting at 0 => January => 0
+    const expenseMonth = expense.date.getMonth(); // starting at 0 (January = 0)
     chartDataPoints[expenseMonth].value += expense.amount;
   }
 


### PR DESCRIPTION
## Summary
- clarify month index comment in `ExpensesChart`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f67ce7883269be151a6e75b2b0c