### PR TITLE
Add React Testing Library test for ExpenseForm toggle

### DIFF
--- a/src/components/NewExpense/ExpenseForm.test.js
+++ b/src/components/NewExpense/ExpenseForm.test.js
@@ -1,0 +1,17 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExpenseForm from './ExpenseForm';
+
+test('clicking "Add new expense" opens the form without submitting', () => {
+  const onSaveExpenseData = jest.fn();
+  render(<ExpenseForm onSaveExpenseData={onSaveExpenseData} />);
+
+  // The button to open the form should be present initially
+  const openButton = screen.getByText(/add new expense/i);
+  fireEvent.click(openButton);
+
+  // After clicking, the Add Expense submit button should be visible
+  const submitButton = screen.getByRole('button', { name: /add expense/i });
+  expect(submitButton).toBeInTheDocument();
+  // onSaveExpenseData should not be called because form was not submitted
+  expect(onSaveExpenseData).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add a new test file for `ExpenseForm` verifying the toggle behaviour

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684060204fc48326ac3942e09335d69c